### PR TITLE
Secured avatar.

### DIFF
--- a/views/public/comment.php
+++ b/views/public/comment.php
@@ -13,7 +13,7 @@
     <p class='comment-author-name'><?php echo $authorText?></p>
     <?php
         $hash = md5(strtolower(trim($comment->author_email)));
-        $url = "http://www.gravatar.com/avatar/$hash";
+        $url = "https://secure.gravatar.com/avatar/$hash";
         echo "<img class='gravatar' src='$url' />";
     ?>
 </div>


### PR DESCRIPTION
Hi,

One of my sites is an https one and I need all contents to be https to avoid a security warning. 
This patch doesn't warn in the inverse case (a http site with some https contents).

Sincerly,

Daniel Berthereau
Infodoc & Knowledge management
