### PR TITLE
Changed from attr() to prop() because of changes in jQuery 1.6: http:…

### DIFF
--- a/config_form.js
+++ b/config_form.js
@@ -1,7 +1,7 @@
 Commenting = {
         toggleCommentOptions: function() {
-            jQuery('div#non-public-options').toggle();
-            if(jQuery(this).attr('checked') == 'checked') {
+        	jQuery('div#non-public-options').toggle();
+            if(jQuery('#commenting_allow_public').prop('checked')) {
                 jQuery('div#commenting-moderate-public').show();
             } else {
                 jQuery('div#commenting-moderate-public').removeAttr('checked');
@@ -15,9 +15,9 @@ Commenting = {
         },
 
         toggleModerateOptions: function() {
-            if( jQuery('input#commenting_allow_public').attr('checked') == 'checked') {
+            if( jQuery('input#commenting_allow_public').prop('checked')) {
                 jQuery('div#commenting-moderate-public').show();
-                if(jQuery('input#commenting_require_public_moderation').attr('checked') == 'checked') {
+                if(jQuery('input#commenting_require_public_moderation').prop('checked')) {
                     jQuery('div#moderate-options').show();
                 } else {
                     jQuery('div#moderate-options').hide();
@@ -36,17 +36,17 @@ jQuery(document).ready(function() {
     jQuery('input#commenting_require_public_moderation').click(Commenting.toggleModerateOptions);
 
     //if public commenting is on
-    if(jQuery('input#commenting_allow_public').attr('checked') == 'checked') {
+    if(jQuery('input#commenting_allow_public').prop('checked')) {
         jQuery('div#non-public-options').hide();
         jQuery('div#commenting-moderate-public').show();
     } else {
         jQuery('div#commenting-moderate-public').hide();
-        jQuery('div#commenting-moderate-public').attr('checked', '');
+        jQuery('div#commenting-moderate-public').removeAttr('checked');
         jQuery('div.moderate-options').show();
     }
 
     Commenting.toggleModerateOptions();
-    if(jQuery('input#commenting_allow_public_view').attr('checked') == 'checked') {
+    if(jQuery('input#commenting_allow_public_view').prop('checked')) {
         jQuery('div.view-options').hide();
     }
 


### PR DESCRIPTION
…//api.jquery.com/prop/

This caused a bug: attr('checked'), or attr('checked') == 'checked' returned undefined or false